### PR TITLE
Fix more non-MPI build issues.

### DIFF
--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -25,6 +25,7 @@
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/distributed/tria.h>
+#include <deal.II/distributed/shared_tria.h>
 
 
 #include <algorithm>

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -72,7 +72,7 @@ namespace parallel
 
   template <int dim, int spacedim>
   void
-  Triangulation<dim,spacedim>::copy_triangulation (const dealii::Triangulation<dim, spacedim> &old_tria)
+  Triangulation<dim,spacedim>::copy_triangulation (const dealii::Triangulation<dim, spacedim> &/*old_tria*/)
   {
     Assert (false, ExcNotImplemented());
   }

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -23,6 +23,8 @@
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/tria_levels.h>
 #include <deal.II/grid/tria.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/distributed/shared_tria.h>
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/fe/fe.h>
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -1004,7 +1004,10 @@ namespace internal
       {
 
 #ifndef DEAL_II_WITH_MPI
+        (void)new_numbers;
         (void)dof_handler;
+        (void)number_cache;
+
         Assert (false, ExcNotImplemented());
 
 #else

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -32,6 +32,8 @@
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/tria.h>
 
+#include <deal.II/distributed/tria.h>
+
 #include <deal.II/fe/fe.h>
 #include <deal.II/hp/dof_handler.h>
 #include <deal.II/hp/fe_collection.h>

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -28,6 +28,7 @@
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/intergrid_map.h>
 #include <deal.II/grid/grid_tools.h>
+#include <deal.II/distributed/tria.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/fe/fe.h>

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -25,6 +25,8 @@
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/tria_levels.h>
 #include <deal.II/grid/tria.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/distributed/shared_tria.h>
 #include <deal.II/fe/fe.h>
 
 #include <set>


### PR DESCRIPTION
This addresses a whole bunch more issues found with GCC 4.6 when compiling
with MPI disabled.
