### PR TITLE
Add more tables on using 2gamma,and add add tables on using gamma.

### DIFF
--- a/examples/step-71/doc/results.dox
+++ b/examples/step-71/doc/results.dox
@@ -57,7 +57,7 @@ and $H^2$-seminorm convergence rates are around 1. The latter two
 match the theoretically expected rates; for the former, we have no
 theorem but are not surprised that it is sub-optimal given the remark
 in the introduction.
-  
+
 
 <h3>Test results on <i>Q<sub>3</sub></i> with <i>&gamma; = p(p+1)</i> </h3>
 
@@ -141,6 +141,48 @@ follow the theoretical expectations, the $H^2$-seminorm does not seem to converg
 Comparing results from $\gamma = 1$ and $\gamma = p(p+1)$, it is clear that
 $\gamma = p(p+1)$ is a better penalty.
 
+<h3>Test results on <i>Q<sub>3</sub></i> with <i>&gamma; = 1</i> </h3>
+
+<table align="center" class="doxtable">
+  <tr>
+   <th>Number of refinements </th><th>  $\|u-u_h^\circ\|_{L_2}$ </th><th>  Conv. rates  </th><th>  $|u-u_h|_{H^1}$ </th><th> Conv. rates </th><th> $|u-u_h|_{H^2}$ </th><th> Conv. rates </th>
+  </tr>
+  <tr>
+   <td>   2                  </td><td>    1.619e-02 </td><td>       </td><td>  2.282e-01  </td><td>           </td><td>  3.370 </td><td>   </td>
+  </tr>
+  <tr>
+   <td>   3                  </td><td>    4.057e-03   </td><td>  1.99  </td><td> 1.127e-01  </td><td>   1.01    </td><td> 3.179  </td><td> 0.08</td>
+  </tr>
+  <tr>
+   <td>   4                  </td><td>   1.033e-03   </td><td> 1.97   </td><td> 5.726e-02    </td><td> 0.97       </td><td>  3.22 </td><td> -0.01 </td>
+  </tr>
+  <tr>
+   <td>   5                  </td><td>   2.551e-04 </td><td>  2.01  </td><td>  2.831e-02 </td><td>   1.01    </td><td> 3.142 </td><td> 0.03   </td>
+  </tr>
+</table>
+This does not converge as theoretical expectations.
+
+<h3>Test results on <i>Q<sub>4</sub></i> with <i>&gamma; = 1</i> </h3>
+
+<table align="center" class="doxtable">
+  <tr>
+   <th>Number of refinements </th><th>  $\|u-u_h^\circ\|_{L_2}$ </th><th>  Conv. rates  </th><th>  $|u-u_h|_{H^1}$ </th><th> Conv. rates </th><th> $|u-u_h|_{H^2}$ </th><th> Conv. rates </th>
+  </tr>
+  <tr>
+   <td>   2                  </td><td>    2.403e-05 </td><td>       </td><td>  7.148e-04  </td><td>           </td><td>  2.804e-02 </td><td>   </td>
+  </tr>
+  <tr>
+   <td>   3                  </td><td>  5.425e-07   </td><td>  5.46 </td><td> 2.853e-05  </td><td>   4.64   </td><td> 1.802e-03 </td><td>3.95</td>
+  </tr>
+  <tr>
+   <td>   4                  </td><td>   1.394e-08   </td><td> 5.28   </td><td> 1.463e-06     </td><td> 4.28     </td><td> 1.962e-04 </td><td> 3.19 </td>
+  </tr>
+  <tr>
+   <td>   5                  </td><td>  5.079e-10 </td><td> 4.77 </td><td>  8.069e-08</td><td>   4.18   </td><td> 2.275e-05 </td><td> 3.10   </td>
+  </tr>
+</table>
+This converges more or less as theoretical expectations.
+
 
 <h3>Test results on <i>Q<sub>2</sub></i> with <i>&gamma; = 2</i> </h3>
 
@@ -172,6 +214,53 @@ is already too small even for the value $p=2$ chosen here, and one can
 readily check that it is indeed too small when using higher polynomial
 degrees.
 
+<h3>Test results on <i>Q<sub>3</sub></i> with <i>&gamma; = 2</i> </h3>
+
+
+<table align="center" class="doxtable">
+  <tr>
+   <th>Number of refinements </th><th>  $\|u-u_h^\circ\|_{L_2}$ </th><th>  Conv. rates  </th><th>  $|u-u_h|_{H^1}$ </th><th> Conv. rates </th><th> $|u-u_h|_{H^2}$ </th><th> Conv. rates </th>
+  </tr>
+  <tr>
+   <td>   2                  </td><td>    4.206e-03 </td><td>       </td><td>   8.508e-02  </td><td>           </td><td> 1.936 </td><td>   </td>
+  </tr>
+  <tr>
+   <td>   3                  </td><td>   2.604e-04   </td><td> 4.01  </td><td> 8.941e-03   </td><td>  3.25   </td><td> 3.926e-01  </td><td> 2.30 </td>
+  </tr>
+  <tr>
+   <td>   4                  </td><td>  1.713e-05   </td><td>  3.92   </td><td> 1.078e-03    </td><td> 3.05      </td><td> 9.365e-02 </td><td> 2.06 </td>
+  </tr>
+  <tr>
+   <td>   5                  </td><td>   1.095e-06  </td><td> 3.96  </td><td> 1.348e-04 </td><td>    3.00  </td><td> 2.337e-02  </td><td> 2.00  </td>
+  </tr>
+</table>
+In this case, the convergence rates follow the
+theoretical expectations.
+
+
+<h3>Test results on <i>Q<sub>4</sub></i> with <i>&gamma; = 2</i> </h3>
+
+
+<table align="center" class="doxtable">
+  <tr>
+   <th>Number of refinements </th><th>  $\|u-u_h^\circ\|_{L_2}$ </th><th>  Conv. rates  </th><th>  $|u-u_h|_{H^1}$ </th><th> Conv. rates </th><th> $|u-u_h|_{H^2}$ </th><th> Conv. rates </th>
+  </tr>
+  <tr>
+   <td>   2                  </td><td>    3.398e-05  </td><td>       </td><td>  9.236e-04  </td><td>           </td><td> 2.760e-02 </td><td>   </td>
+  </tr>
+  <tr>
+   <td>   3                  </td><td>   7.241e-07  </td><td>5.55  </td><td> 3.820e-05   </td><td>  4.59  </td><td> 2.373e-03  </td><td> 3.53 </td>
+  </tr>
+  <tr>
+   <td>   4                  </td><td>  1.740e-08  </td><td> 5.37 </td><td> 1.826e-06    </td><td> 4.38    </td><td> 2.366e-04 </td><td> 3.32 </td>
+  </tr>
+  <tr>
+   <td>   5                  </td><td>    4.476e-10 </td><td> 5.28 </td><td> 9.375e-08 </td><td>   4.28 </td><td> 2.548e-05  </td><td> 3.21  </td>
+  </tr>
+</table>
+In this case, the convergence rates more or less follow the
+theoretical expectations.
+
 
 <h3> Conclusions for the choice of the penalty parameter </h3>
 
@@ -201,3 +290,220 @@ make sense:
   FEInterfaceValues class combined with MeshWorker::mesh_loop() in the
   same spirit as we used for the assembly of the linear system.
 
+
+  <h3> Results of taking <i>&gamma;</i> in the boundary assembler </h3>
+
+  In the program, we use the $2\gamma$ in the `boundary_worker` but $\gamma$
+  in the `face_worker`. Results are presented previously.
+  Here, `boundary_worker` and `face_worker` have both $\gamma$.
+  We will present numerical results.
+
+  <h3>Test results on <i>Q<sub>2</sub></i> with <i>&gamma; = p(p+1)</i> </h3>
+
+  <table align="center" class="doxtable">
+    <tr>
+     <th>Number of refinements </th><th>  $\|u-u_h^\circ\|_{L_2}$ </th><th>  Conv. rates  </th><th>  $|u-u_h|_{H^1}$ </th><th> Conv. rates </th><th> $|u-u_h|_{H^2}$ </th><th> Conv. rates </th>
+    </tr>
+    <tr>
+     <td>   2                  </td><td>   8.780e-03 </td><td>       </td><td>  7.095e-02   </td><td>           </td><td>  1.645 </td><td>   </td>
+    </tr>
+    <tr>
+     <td>   3                  </td><td>   3.515e-03   </td><td>  1.32 </td><td> 2.174e-02  </td><td>     1.70     </td><td> 8.121e-01  </td><td>  1.018  </td>
+    </tr>
+    <tr>
+     <td>   4                  </td><td>   1.103e-03   </td><td>  1.67   </td><td> 6.106e-03    </td><td>  1.83        </td><td>   4.015e-01 </td><td> 1.016  </td>
+    </tr>
+    <tr>
+     <td>   5                  </td><td>  3.084e-04  </td><td>  1.83   </td><td>  1.622e-03   </td><td>    1.91        </td><td> 1.993e-01 </td><td>  1.010   </td>
+    </tr>
+  </table>
+  We can see in this case, convergence rates satisfy theoretical expectations.
+  Comparing taking $\gamma$ and taking $2\gamma$ in the `boundary_worker`,
+  $2\gamma$ converges better.
+
+
+  <h3>Test results on <i>Q<sub>3</sub></i> with <i>&gamma; = p(p+1)</i> </h3>
+
+  <table align="center" class="doxtable">
+    <tr>
+     <th>Number of refinements </th><th>  $\|u-u_h^\circ\|_{L_2}$ </th><th>  Conv. rates  </th><th>  $|u-u_h|_{H^1}$ </th><th> Conv. rates </th><th> $|u-u_h|_{H^2}$ </th><th> Conv. rates </th>
+    </tr>
+    <tr>
+     <td>   2                  </td><td>    2.045e-04 </td><td>       </td><td>   4.402e-03   </td><td>           </td><td> 1.641e-01 </td><td>   </td>
+    </tr>
+    <tr>
+     <td>   3                  </td><td>   1.312e-05   </td><td> 3.96  </td><td>  5.537e-04  </td><td>   2.99     </td><td> 4.096e-02 </td><td>  2.00  </td>
+    </tr>
+    <tr>
+     <td>   4                  </td><td>   8.239e-07 </td><td>  3.99  </td><td> 6.904e-05   </td><td> 3.00     </td><td> 1.023e-02 </td><td> 2.00 </td>
+    </tr>
+    <tr>
+     <td>   5                  </td><td>   5.158e-08  </td><td>  3.99 </td><td> 8.621e-06 </td><td>  3.00      </td><td> 2.558e-03  </td><td>  2.00  </td>
+    </tr>
+  </table>
+  We can see that the $L_2$ norm convergence rates are around 4,
+  $H^1$-seminorm convergence rates are around 3,
+  and $H^2$-seminorm convergence rates are around 2.
+  Results of this case are pretty close to the case with $2\gamma$ in `boundary_worker`.
+
+
+  <h3>Test results on <i>Q<sub>4</sub></i> with <i>&gamma; = p(p+1)</i> </h3>
+
+  <table align="center" class="doxtable">
+    <tr>
+     <th>Number of refinements </th><th>  $\|u-u_h^\circ\|_{L_2}$ </th><th>  Conv. rates  </th><th>  $|u-u_h|_{H^1}$ </th><th> Conv. rates </th><th> $|u-u_h|_{H^2}$ </th><th> Conv. rates </th>
+    </tr>
+    <tr>
+     <td>   2                  </td><td>    6.510e-06 </td><td>       </td><td> 2.215e-04   </td><td>           </td><td>  1.275e-02 </td><td>   </td>
+    </tr>
+    <tr>
+     <td>   3                  </td><td>   2.679e-07  </td><td>  4.60  </td><td> 1.569e-05  </td><td>   3.81    </td><td> 1.496e-03 </td><td>  3.09  </td>
+    </tr>
+    <tr>
+     <td>   4                  </td><td>   9.404e-09  </td><td> 4.83   </td><td> 1.040e-06    </td><td> 3.91       </td><td> 1.774e-04 </td><td> 3.07 </td>
+    </tr>
+    <tr>
+     <td>   5                  </td><td>   7.943e-10 </td><td>  3.56  </td><td>   6.693e-08 </td><td> 3.95     </td><td> 2.150e-05  </td><td> 3.04    </td>
+    </tr>
+  </table>
+  We can see that the $L_2$ norm convergence rates are around 5,
+  $H^1$-seminorm convergence rates are around 4,
+  and $H^2$-seminorm convergence rates are around 3.
+  The $L_2$ norm convergence rate in this case is the same as taking $2\gamma$ previously.
+  On the finest mesh, it is much smaller than our theoretical expectations
+  but the $L_2$ error is also very small already in
+  that case.
+
+
+  <h3>Test results on <i>Q<sub>2</sub></i> with <i>&gamma; = 1</i> </h3>
+
+  Let us now also consider the
+  case where we simply choose $\gamma=1$:
+
+  <table align="center" class="doxtable">
+    <tr>
+     <th>Number of refinements </th><th>  $\|u-u_h^\circ\|_{L_2}$ </th><th>  Conv. rates  </th><th>  $|u-u_h|_{H^1}$ </th><th> Conv. rates </th><th> $|u-u_h|_{H^2}$ </th><th> Conv. rates </th>
+    </tr>
+    <tr>
+     <td>   2                  </td><td>   7.350e-02 </td><td>       </td><td>   7.323e-01   </td><td>           </td><td> 10.343 </td><td>   </td>
+    </tr>
+    <tr>
+     <td>   3                  </td><td>   6.798e-03   </td><td> 3.43  </td><td> 1.716e-01   </td><td>   2.09    </td><td>4.836 </td><td>  1.09 </td>
+    </tr>
+    <tr>
+     <td>   4                  </td><td>  9.669e-04   </td><td> 2.81   </td><td> 6.436e-02    </td><td> 1.41      </td><td>  3.590 </td><td> 0.430 </td>
+    </tr>
+    <tr>
+     <td>   5                  </td><td>   1.755e-04 </td><td> 2.46 </td><td>  2.831e-02  </td><td>    1.18      </td><td>3.144  </td><td>  0.19  </td>
+    </tr>
+  </table>
+  $H^2$-seminorm does not converge as we expected.
+
+  <h3>Test results on <i>Q<sub>3</sub></i> with <i>&gamma; = 1</i> </h3>
+
+  <table align="center" class="doxtable">
+    <tr>
+     <th>Number of refinements </th><th>  $\|u-u_h^\circ\|_{L_2}$ </th><th>  Conv. rates  </th><th>  $|u-u_h|_{H^1}$ </th><th> Conv. rates </th><th> $|u-u_h|_{H^2}$ </th><th> Conv. rates </th>
+    </tr>
+    <tr>
+     <td>   2                  </td><td>   2.164e-01 </td><td>       </td><td>   3.294   </td><td>           </td><td> 48.561 </td><td>   </td>
+    </tr>
+    <tr>
+     <td>   3                  </td><td>   9.232e-03  </td><td> 4.55  </td><td> 2.921e-01   </td><td>  3.49    </td><td>8.258 </td><td>  2.55 </td>
+    </tr>
+    <tr>
+     <td>   4                  </td><td> 9.850e-04   </td><td> 3.22  </td><td> 6.558e-02    </td><td> 2.15    </td><td> 3.659</td><td> 1.17 </td>
+    </tr>
+    <tr>
+     <td>   5                  </td><td>  1.639e-04 </td><td> 2.58 </td><td>  2.274e-02  </td><td>    1.52     </td><td>2.526 </td><td>  0.53  </td>
+    </tr>
+  </table>
+  None of these three norms converge as we expected.
+
+
+  <h3>Test results on <i>Q<sub>4</sub></i> with <i>&gamma; = 1</i> </h3>
+
+  <table align="center" class="doxtable">
+    <tr>
+     <th>Number of refinements </th><th>  $\|u-u_h^\circ\|_{L_2}$ </th><th>  Conv. rates  </th><th>  $|u-u_h|_{H^1}$ </th><th> Conv. rates </th><th> $|u-u_h|_{H^2}$ </th><th> Conv. rates </th>
+    </tr>
+    <tr>
+     <td>   2                  </td><td>   2.139e-05 </td><td>       </td><td>  5.739e-04   </td><td>           </td><td> 1.753e-02 </td><td>   </td>
+    </tr>
+    <tr>
+     <td>   3                  </td><td>  5.516e-07   </td><td> 5.27  </td><td> 3.468e-05   </td><td>  4.04  </td><td> 2.66873e-03 </td><td> 2.71</td>
+    </tr>
+    <tr>
+     <td>   4                  </td><td> 1.334e-08   </td><td> 5.36 </td><td> 1.399e-06      </td><td> 4.63   </td><td> 1.89247e-04 </td><td> 3.81 </td>
+    </tr>
+    <tr>
+     <td>   5                  </td><td>  4.870e-10  </td><td> 4.77</td><td>7.839e-08  </td><td>   4.15    </td><td> 2.224e-05 </td><td> 3.08  </td>
+    </tr>
+  </table>
+  With higher order degrees, results converge much closer to theoretical expectations.
+
+  <h3>Test results on <i>Q<sub>2</sub></i> with <i>&gamma; = 2</i> </h3>
+
+  Let us now also consider the
+  case where we simply choose $\gamma=2$:
+
+  <table align="center" class="doxtable">
+    <tr>
+     <th>Number of refinements </th><th>  $\|u-u_h^\circ\|_{L_2}$ </th><th>  Conv. rates  </th><th>  $|u-u_h|_{H^1}$ </th><th> Conv. rates </th><th> $|u-u_h|_{H^2}$ </th><th> Conv. rates </th>
+    </tr>
+    <tr>
+     <td>   2                  </td><td>   4.133e-02 </td><td>       </td><td>  2.517e-01   </td><td>           </td><td> 3.056 </td><td>   </td>
+    </tr>
+    <tr>
+     <td>   3                  </td><td>  6.500e-03   </td><td>2.66  </td><td> 5.916e-02  </td><td>  2.08    </td><td>1.444 </td><td>  1.08 </td>
+    </tr>
+    <tr>
+     <td>   4                  </td><td> 6.780e-04   </td><td> 3.26  </td><td> 1.203e-02    </td><td> 2.296      </td><td> 6.151e-01 </td><td> 1.231 </td>
+    </tr>
+    <tr>
+     <td>   5                  </td><td> 1.622e-04 </td><td> 2.06 </td><td>  2.448e-03  </td><td>   2.297     </td><td> 2.618e-01  </td><td> 1.232  </td>
+    </tr>
+  </table>
+  The $H^1$-seminorm does not seem to converge as well as taking $2\gamma$ in `boundary_worker`.
+
+  <h3>Test results on <i>Q<sub>3</sub></i> with <i>&gamma; = 2</i> </h3>
+
+  <table align="center" class="doxtable">
+    <tr>
+     <th>Number of refinements </th><th>  $\|u-u_h^\circ\|_{L_2}$ </th><th>  Conv. rates  </th><th>  $|u-u_h|_{H^1}$ </th><th> Conv. rates </th><th> $|u-u_h|_{H^2}$ </th><th> Conv. rates </th>
+    </tr>
+    <tr>
+     <td>   2                  </td><td>  1.748e-03 </td><td>       </td><td>  2.446e-02   </td><td>           </td><td> 4.893e-01 </td><td>   </td>
+    </tr>
+    <tr>
+     <td>   3                  </td><td> 7.402e-05    </td><td>4.56  </td><td> 2.777e-03  </td><td>  3.13   </td><td> 1.067e-01 </td><td>2.19</td>
+    </tr>
+    <tr>
+     <td>   4                  </td><td> 4.341e-06    </td><td> 4.09 </td><td> 3.334e-04   </td><td>3.05     </td><td> 2.519e-02 </td><td> 2.08 </td>
+    </tr>
+    <tr>
+     <td>   5                  </td><td>2.666e-07 </td><td> 4.02 </td><td>  4.117e-05  </td><td>  3.01   </td><td> 6.182e-03 </td><td> 2.02  </td>
+    </tr>
+  </table>
+  This follows the theoretical expectations.
+
+
+  <h3>Test results on <i>Q<sub>4</sub></i> with <i>&gamma; = 2</i> </h3>
+
+  <table align="center" class="doxtable">
+    <tr>
+     <th>Number of refinements </th><th>  $\|u-u_h^\circ\|_{L_2}$ </th><th>  Conv. rates  </th><th>  $|u-u_h|_{H^1}$ </th><th> Conv. rates </th><th> $|u-u_h|_{H^2}$ </th><th> Conv. rates </th>
+    </tr>
+    <tr>
+     <td>   2                  </td><td>  2.585e-05 </td><td>       </td><td> 6.938e-04  </td><td>           </td><td> 2.03217e-02</td><td>   </td>
+    </tr>
+    <tr>
+     <td>   3                  </td><td> 5.778e-07  </td><td>5.48  </td><td> 3.036e-05 </td><td>  4.51   </td><td> 1.901e-03 </td><td>3.41 </td>
+    </tr>
+    <tr>
+     <td>   4                  </td><td> 1.456e-08  </td><td> 5.31</td><td> 1.533e-06 </td><td>4.30    </td><td> 2.061e-04 </td><td> 3.20 </td>
+    </tr>
+    <tr>
+     <td>   5                  </td><td>3.943e-10 </td><td> 5.20</td><td> 8.263e-08  </td><td> 4.21  </td><td> 2.303e-05 </td><td> 3.16 </td>
+    </tr>
+  </table>


### PR DESCRIPTION
In the 2gamma case, I add results of the test example on Q3 with gamma = 1, on Q4 with gamma = 1, on Q3 with gamma = 2, and Q4 with gamma = 2. From the results, we can see that smaller penalties don't work well on Q2 elements, but if we test it on higher orders, like Q4, the results converge as theoretical expectations. 

In the gamma case, I add tables of all conditions.